### PR TITLE
feat: add yes/no confirmation dialog for worktree removal

### DIFF
--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -63,10 +63,9 @@ var removeCmd = &cobra.Command{
 
 		if result.Action == "remove" || result.Action == "delete" {
 			// Confirm removal
-			confirmModel := ui.NewInput(
+			confirmModel := ui.NewConfirm(
 				"Confirm Removal",
-				[]string{fmt.Sprintf("Type 'yes' to remove worktree at %s", result.Worktree.Path)},
-				[]string{""},
+				fmt.Sprintf("Remove worktree at %s?", result.Worktree.Path),
 			)
 			program := tea.NewProgram(confirmModel)
 
@@ -75,8 +74,8 @@ var removeCmd = &cobra.Command{
 				return fmt.Errorf("failed to run confirmation interface: %w", err)
 			}
 
-			confirmResult := finalConfirmModel.(ui.InputModel).GetResult()
-			if !confirmResult.Submitted || len(confirmResult.Values) == 0 || confirmResult.Values[0] != "yes" {
+			confirmResult := finalConfirmModel.(ui.ConfirmModel).GetResult()
+			if confirmResult.Cancelled || !confirmResult.Confirmed {
 				fmt.Println("Removal cancelled")
 				return nil
 			}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -39,8 +39,8 @@ func TestRootCommand(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "No arguments (should run default list behavior)",
-			args: []string{},
+			name:           "No arguments (should run default list behavior)",
+			args:           []string{},
 			expectedOutput: []string{
 				// Running in git repo, should work without error
 			},

--- a/internal/ui/confirm.go
+++ b/internal/ui/confirm.go
@@ -1,0 +1,167 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type confirmKeyMap struct {
+	Up    key.Binding
+	Down  key.Binding
+	Left  key.Binding
+	Right key.Binding
+	Yes   key.Binding
+	No    key.Binding
+	Enter key.Binding
+	Quit  key.Binding
+}
+
+var confirmKeys = confirmKeyMap{
+	Up: key.NewBinding(
+		key.WithKeys("up", "k"),
+		key.WithHelp("↑/k", "select yes"),
+	),
+	Down: key.NewBinding(
+		key.WithKeys("down", "j"),
+		key.WithHelp("↓/j", "select no"),
+	),
+	Left: key.NewBinding(
+		key.WithKeys("left", "h"),
+		key.WithHelp("←/h", "select yes"),
+	),
+	Right: key.NewBinding(
+		key.WithKeys("right", "l"),
+		key.WithHelp("→/l", "select no"),
+	),
+	Yes: key.NewBinding(
+		key.WithKeys("y"),
+		key.WithHelp("y", "yes"),
+	),
+	No: key.NewBinding(
+		key.WithKeys("n"),
+		key.WithHelp("n", "no"),
+	),
+	Enter: key.NewBinding(
+		key.WithKeys("enter"),
+		key.WithHelp("enter", "confirm"),
+	),
+	Quit: key.NewBinding(
+		key.WithKeys("q", "ctrl+c", "esc"),
+		key.WithHelp("q/esc", "cancel"),
+	),
+}
+
+type ConfirmModel struct {
+	title     string
+	message   string
+	selected  bool // true = yes, false = no
+	confirmed bool
+	cancelled bool
+}
+
+type ConfirmResult struct {
+	Confirmed bool // true if user selected yes, false if no or cancelled
+	Cancelled bool // true if user cancelled (q/esc)
+}
+
+func NewConfirm(title, message string) ConfirmModel {
+	return ConfirmModel{
+		title:    title,
+		message:  message,
+		selected: false, // default to "no" for safety
+	}
+}
+
+func (m ConfirmModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m ConfirmModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, confirmKeys.Quit):
+			m.cancelled = true
+			return m, tea.Quit
+
+		case key.Matches(msg, confirmKeys.Up), key.Matches(msg, confirmKeys.Left):
+			m.selected = true
+
+		case key.Matches(msg, confirmKeys.Down), key.Matches(msg, confirmKeys.Right):
+			m.selected = false
+
+		case key.Matches(msg, confirmKeys.Yes):
+			m.selected = true
+			m.confirmed = true
+			return m, tea.Quit
+
+		case key.Matches(msg, confirmKeys.No):
+			m.selected = false
+			m.confirmed = true
+			return m, tea.Quit
+
+		case key.Matches(msg, confirmKeys.Enter):
+			m.confirmed = true
+			return m, tea.Quit
+		}
+	}
+
+	return m, nil
+}
+
+func (m ConfirmModel) View() string {
+	if m.cancelled || m.confirmed {
+		return ""
+	}
+
+	var b strings.Builder
+
+	// Title
+	b.WriteString(TitleStyle.Render(fmt.Sprintf("⚠️  %s", m.title)))
+	b.WriteString("\n\n")
+
+	// Message
+	b.WriteString(NormalStyle.Render(m.message))
+	b.WriteString("\n\n")
+
+	// Options
+	yesStyle := NormalStyle
+	noStyle := NormalStyle
+
+	if m.selected {
+		yesStyle = SelectedItemStyle
+	} else {
+		noStyle = SelectedItemStyle
+	}
+
+	b.WriteString("  ")
+	b.WriteString(yesStyle.Render("[ Yes ]"))
+	b.WriteString("    ")
+	b.WriteString(noStyle.Render("[ No ]"))
+	b.WriteString("\n\n")
+
+	// Help
+	helpText := []string{
+		"←/→/h/l switch", "↑/↓/k/j switch", "y yes", "n no", "enter confirm", "q/esc cancel",
+	}
+	b.WriteString(HelpStyle.Render(strings.Join(helpText, " • ")))
+
+	return BorderStyle.Render(b.String())
+}
+
+func (m ConfirmModel) GetResult() ConfirmResult {
+	if m.cancelled {
+		return ConfirmResult{
+			Confirmed: false,
+			Cancelled: true,
+		}
+	}
+
+	return ConfirmResult{
+		Confirmed: m.confirmed && m.selected,
+		Cancelled: false,
+	}
+}

--- a/internal/ui/confirm_test.go
+++ b/internal/ui/confirm_test.go
@@ -1,0 +1,203 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestNewConfirm(t *testing.T) {
+	tests := []struct {
+		name     string
+		title    string
+		message  string
+		expected ConfirmModel
+	}{
+		{
+			name:    "creates confirm model with title and message",
+			title:   "Test Title",
+			message: "Test Message",
+			expected: ConfirmModel{
+				title:    "Test Title",
+				message:  "Test Message",
+				selected: false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewConfirm(tt.title, tt.message)
+			if model.title != tt.expected.title {
+				t.Errorf("Expected title %s, got %s", tt.expected.title, model.title)
+			}
+			if model.message != tt.expected.message {
+				t.Errorf("Expected message %s, got %s", tt.expected.message, model.message)
+			}
+			if model.selected != tt.expected.selected {
+				t.Errorf("Expected selected %v, got %v", tt.expected.selected, model.selected)
+			}
+		})
+	}
+}
+
+func TestConfirmUpdate(t *testing.T) {
+	tests := []struct {
+		name           string
+		initial        ConfirmModel
+		msg            tea.Msg
+		expectedSelect bool
+		shouldQuit     bool
+	}{
+		{
+			name:           "up key selects yes",
+			initial:        NewConfirm("Test", "Message"),
+			msg:            tea.KeyMsg{Type: tea.KeyUp},
+			expectedSelect: true,
+			shouldQuit:     false,
+		},
+		{
+			name:           "down key selects no",
+			initial:        ConfirmModel{selected: true},
+			msg:            tea.KeyMsg{Type: tea.KeyDown},
+			expectedSelect: false,
+			shouldQuit:     false,
+		},
+		{
+			name:           "left key selects yes",
+			initial:        NewConfirm("Test", "Message"),
+			msg:            tea.KeyMsg{Type: tea.KeyLeft},
+			expectedSelect: true,
+			shouldQuit:     false,
+		},
+		{
+			name:           "right key selects no",
+			initial:        ConfirmModel{selected: true},
+			msg:            tea.KeyMsg{Type: tea.KeyRight},
+			expectedSelect: false,
+			shouldQuit:     false,
+		},
+		{
+			name:           "y key selects yes and quits",
+			initial:        NewConfirm("Test", "Message"),
+			msg:            tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}},
+			expectedSelect: true,
+			shouldQuit:     true,
+		},
+		{
+			name:           "n key selects no and quits",
+			initial:        ConfirmModel{selected: true},
+			msg:            tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}},
+			expectedSelect: false,
+			shouldQuit:     true,
+		},
+		{
+			name:           "enter key confirms current selection",
+			initial:        ConfirmModel{selected: true},
+			msg:            tea.KeyMsg{Type: tea.KeyEnter},
+			expectedSelect: true,
+			shouldQuit:     true,
+		},
+		{
+			name:           "q key cancels",
+			initial:        NewConfirm("Test", "Message"),
+			msg:            tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}},
+			expectedSelect: false,
+			shouldQuit:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updatedModel, cmd := tt.initial.Update(tt.msg)
+			model := updatedModel.(ConfirmModel)
+
+			if model.selected != tt.expectedSelect {
+				t.Errorf("Expected selected %v, got %v", tt.expectedSelect, model.selected)
+			}
+
+			if tt.shouldQuit && cmd == nil {
+				t.Error("Expected quit command, got nil")
+			}
+		})
+	}
+}
+
+func TestConfirmGetResult(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    ConfirmModel
+		expected ConfirmResult
+	}{
+		{
+			name: "confirmed yes",
+			model: ConfirmModel{
+				confirmed: true,
+				selected:  true,
+			},
+			expected: ConfirmResult{
+				Confirmed: true,
+				Cancelled: false,
+			},
+		},
+		{
+			name: "confirmed no",
+			model: ConfirmModel{
+				confirmed: true,
+				selected:  false,
+			},
+			expected: ConfirmResult{
+				Confirmed: false,
+				Cancelled: false,
+			},
+		},
+		{
+			name: "cancelled",
+			model: ConfirmModel{
+				cancelled: true,
+			},
+			expected: ConfirmResult{
+				Confirmed: false,
+				Cancelled: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.model.GetResult()
+			if result.Confirmed != tt.expected.Confirmed {
+				t.Errorf("Expected Confirmed %v, got %v", tt.expected.Confirmed, result.Confirmed)
+			}
+			if result.Cancelled != tt.expected.Cancelled {
+				t.Errorf("Expected Cancelled %v, got %v", tt.expected.Cancelled, result.Cancelled)
+			}
+		})
+	}
+}
+
+func TestConfirmView(t *testing.T) {
+	t.Run("shows empty string when cancelled", func(t *testing.T) {
+		model := ConfirmModel{cancelled: true}
+		view := model.View()
+		if view != "" {
+			t.Errorf("Expected empty view when cancelled, got %s", view)
+		}
+	})
+
+	t.Run("shows empty string when confirmed", func(t *testing.T) {
+		model := ConfirmModel{confirmed: true}
+		view := model.View()
+		if view != "" {
+			t.Errorf("Expected empty view when confirmed, got %s", view)
+		}
+	})
+
+	t.Run("shows content when active", func(t *testing.T) {
+		model := NewConfirm("Test Title", "Test Message")
+		view := model.View()
+		if view == "" {
+			t.Error("Expected non-empty view when active")
+		}
+	})
+}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -87,6 +87,9 @@ var (
 			Bold(true).
 			Padding(0, 1)
 
+	NormalStyle = lipgloss.NewStyle().
+			Foreground(Text)
+
 	BorderStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(Primary).


### PR DESCRIPTION
## Summary
- Add dedicated yes/no confirmation dialog component for improved UX
- Replace text-based confirmation with intuitive arrow key navigation
- Enhance user experience for destructive operations like worktree removal

## Changes
- **New Component**: Added `ConfirmModel` in `internal/ui/confirm.go`
  - Arrow key navigation between Yes/No options
  - Enter to confirm selection, Esc to cancel
  - Visual highlighting of selected option
  
- **Updated Remove Command**: Modified `cmd/remove.go` to use the new confirmation dialog
  - Replaced `ui.NewInput` with `ui.NewConfirm`
  - Clearer confirmation flow with better visual feedback
  
- **Comprehensive Tests**: Added tests for the new confirm component
  - Test initial state and navigation
  - Test keyboard interactions
  - Test result handling

## Test plan
- [x] Unit tests added for ConfirmModel
- [x] Manual testing of worktree removal with new dialog
- [x] Verified arrow key navigation works correctly
- [x] Confirmed Enter/Esc key behavior

🤖 Generated with [Claude Code](https://claude.ai/code)