### PR TITLE
feat: add keyboard shortcuts for create and delete actions in list command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 	"github.com/yagi2/yosegi/internal/config"
-	"github.com/yagi2/yosegi/internal/git"
 	"github.com/yagi2/yosegi/internal/ui"
 )
 
@@ -18,31 +16,8 @@ var rootCmd = &cobra.Command{
 It provides visual and intuitive commands to create, list, and manage git worktrees.`,
 	Version: "0.1.0",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		manager, err := git.NewManager()
-		if err != nil {
-			return fmt.Errorf("failed to initialize git manager: %w", err)
-		}
-
-		worktrees, err := manager.List()
-		if err != nil {
-			return fmt.Errorf("failed to list worktrees: %w", err)
-		}
-
-		// Interactive mode
-		model := ui.NewSelector(worktrees, "Git Worktrees", "view", false)
-		program := tea.NewProgram(model)
-
-		finalModel, err := program.Run()
-		if err != nil {
-			return fmt.Errorf("failed to run interactive interface: %w", err)
-		}
-
-		result := finalModel.(ui.SelectorModel).GetResult()
-		if result.Action == "select" {
-			fmt.Printf("Selected worktree: %s (%s)\n", result.Worktree.Path, result.Worktree.Branch)
-		}
-
-		return nil
+		// Use the same functionality as list command
+		return listCmd.RunE(cmd, args)
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.5
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/spf13/cobra v1.9.1
+	github.com/spf13/pflag v1.0.6
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -27,7 +28,6 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.13.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -29,7 +29,7 @@ func NewInput(title string, prompts []string, defaults []string) InputModel {
 		input := textinput.New()
 		input.Placeholder = prompt
 		input.CharLimit = 200
-		input.Width = 50  // Set width to display placeholder properly
+		input.Width = 50 // Set width to display placeholder properly
 
 		if i < len(defaults) && defaults[i] != "" {
 			input.SetValue(defaults[i])


### PR DESCRIPTION
## Summary

- Add keyboard shortcuts to the list command for improved user experience
- 'c' key allows creating new worktree directly from the list view
- 'd' key enables deleting selected worktree with confirmation dialog
- Integrate list functionality with existing new and remove commands
- Make root command use list command as default behavior for better UX

## Key Changes

- Enhanced `SelectorModel` with create action support
- Added `runRemoveWithSelectedWorktree` function for direct deletion
- Updated help text to show new keyboard shortcuts
- Improved action handling in list command with switch statement
- Unified root command behavior with list command

## Test Plan

- [x] Test 'c' key creates new worktree from list view
- [x] Test 'd' key deletes selected worktree with confirmation
- [x] Test Enter key still selects and prints worktree path
- [x] Test quit functionality remains unchanged
- [x] Test root command defaults to list behavior
- [x] Verify integration with existing new and remove commands

Close #3 

🤖 Generated with [Claude Code](https://claude.ai/code)